### PR TITLE
Expose properties to configure the button title's shadow appearance.

### DIFF
--- a/TSPopover/TSActionSheet.h
+++ b/TSPopover/TSActionSheet.h
@@ -23,6 +23,8 @@
 @property (nonatomic) BOOL popoverGradient; 
 @property (nonatomic) BOOL buttonGradient;
 @property (nonatomic) BOOL titleShadow;
+@property (strong, nonatomic) UIColor *titleShadowColor;
+@property (nonatomic) CGSize titleShadowOffset;
 
 - (id)initWithTitle:(NSString *)title;
 - (void)cancelButtonWithTitle:(NSString *) title block:(void (^)()) block;

--- a/TSPopover/TSActionSheet.m
+++ b/TSPopover/TSActionSheet.m
@@ -24,7 +24,8 @@
 @synthesize popoverGradient = _popoverGradient;
 @synthesize buttonGradient = _buttonGradient;
 @synthesize titleShadow = _titleShadow;
-
+@synthesize titleShadowColor = _titleShadowColor;
+@synthesize titleShadowOffset = _titleShadowOffset;
 
 - (id)initWithTitle:(NSString *)title 
 {
@@ -36,6 +37,8 @@
         self.buttonGradient = YES;
         self.titleShadow = YES;
         self.titleColor = [UIColor whiteColor];
+        self.titleShadowOffset = TITLE_SHADOW_OFFSET;
+        self.titleShadowColor = [UIColor blackColor];
         
         popoverController = [[TSPopoverController alloc] init];
         popoverController.titleText = title;
@@ -127,8 +130,8 @@
         button.accessibilityLabel = title;
         
         if(self.titleShadow){
-            [button setTitleShadowColor:[UIColor blackColor] forState:UIControlStateNormal];
-            button.titleLabel.shadowOffset = TITLE_SHADOW_OFFSET;
+            [button setTitleShadowColor:self.titleShadowColor forState:UIControlStateNormal];
+            button.titleLabel.shadowOffset = self.titleShadowOffset;
         }
         
         [button addTarget:self action:@selector(buttonClicked:) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
The shadow color and offset are currently hard-coded values.  This change
provides properties for these parameters that default to the original
values.

UIButtons are not configurable via the UIAppearance proxy in iOS5, otherwise
this change would not be necessary.
