### PR TITLE
Fix broken popover frame, on TSPopoverArrowDirectionBottom

### DIFF
--- a/TSPopover/TSPopoverController.m
+++ b/TSPopover/TSPopoverController.m
@@ -252,6 +252,9 @@
     contentFrameRect.origin.y = MARGIN;
     
     float statusBarHeight = [[UIApplication sharedApplication] statusBarFrame].size.height;
+    if(self.interfaceOrientation == UIInterfaceOrientationLandscapeLeft || self.interfaceOrientation == UIInterfaceOrientationLandscapeRight){
+        statusBarHeight = [[UIApplication sharedApplication] statusBarFrame].size.width;
+    }
 
 
     if(self.arrowPosition == TSPopoverArrowPositionVertical){


### PR DESCRIPTION
Fix broken TSPopover's frame, 
If device orientation is landscape and arrowDirection==TSPopoverArrowDirectionBottom.
